### PR TITLE
Foundation Model Performance Improvements

### DIFF
--- a/surya/foundation/cache.py
+++ b/surya/foundation/cache.py
@@ -313,8 +313,7 @@ class ContinuousBatchingCache():
 
         return key_cache, value_cache
 
-    # The attention mask managed by our kv cache automatically masks the tokens
-    # in the cache, so we can return full length for HF to use in other places
-    # This is mainly utilized in the cache_positions creation
+    # We have a non-uniform cache, so its better to not return it and handle any logic
+    # that requires this ourselves
     def get_seq_length(self, layer_idx: Optional[int] = 0) -> int:
-        return self.max_cache_len
+        raise NotImplementedError()

--- a/surya/recognition/__init__.py
+++ b/surya/recognition/__init__.py
@@ -415,8 +415,11 @@ class RecognitionPredictor(BasePredictor):
                 for im in images
             ]
 
-        # Sort by line widths. Negative so that longer images come first, fits in with continuous batching better
-        sorted_pairs = sorted(enumerate(flat["slices"]), key=lambda x: -x[1].shape[1])
+        # Sort by image sizes. Negative so that longer images come first, fits in with continuous batching better
+        sorted_pairs = sorted(
+            enumerate(flat["slices"]),
+            key=lambda x: -(x[1].shape[0] * x[1].shape[1])  # height * width
+        )
         indices, sorted_slices = zip(*sorted_pairs)
 
         # Reorder input_text and task_names based on the new order


### PR DESCRIPTION
- Cache position was computed wrong, so we were setting the wrong 4D attention mask during prefill. 
Fixed the cache position by passing in from outside the model, based on the 2D attention mask, similar to how we compute `cache_seqlens` in the flash attention function
- Sorting images by total size now, since using block mode. Much better for continuous batching