### PR TITLE
fix(prompts): use [0-9] instead of \d in the bbox schema pattern (#542)

### DIFF
--- a/surya/inference/prompts.py
+++ b/surya/inference/prompts.py
@@ -127,7 +127,7 @@ LAYOUT_JSON_SCHEMA = {
             "label": {"type": "string", "enum": LAYOUT_LABEL_SET},
             "bbox": {
                 "type": "string",
-                "pattern": r"^\d{1,4} \d{1,4} \d{1,4} \d{1,4}$",
+                "pattern": r"^[0-9]{1,4} [0-9]{1,4} [0-9]{1,4} [0-9]{1,4}$",
             },
             "count": {"type": "integer", "minimum": 0, "maximum": 10000},
         },
@@ -149,7 +149,7 @@ TABLE_REC_JSON_SCHEMA = {
             "label": {"type": "string", "enum": TABLE_REC_LABEL_SET},
             "bbox": {
                 "type": "string",
-                "pattern": r"^\d{1,4} \d{1,4} \d{1,4} \d{1,4}$",
+                "pattern": r"^[0-9]{1,4} [0-9]{1,4} [0-9]{1,4} [0-9]{1,4}$",
             },
         },
         "required": ["label", "bbox"],


### PR DESCRIPTION
Fixes #542.

## Problem

`LAYOUT_JSON_SCHEMA` and `TABLE_REC_JSON_SCHEMA` constrain `bbox` with

```python
"pattern": r"^\d{1,4} \d{1,4} \d{1,4} \d{1,4}$",
```

llama.cpp's `json_schema_to_grammar` copies a JSON Schema `pattern` into GBNF
essentially verbatim, and GBNF has no `\d` escape. So the schema is turned into

```
response-format-schema-item-bbox ::= "\"" ("\d"{1,4} " \d"{1,4} " \d"{1,4} " \d"{1,4}) "\""
```

and llama-server rejects it before sampling starts:

```
parse: error parsing grammar: unknown escape at \d"{1,4} " \d"{1,4} " \d"{1,4} " \d"{1,4}) "\""
E failed to parse grammar
Error code: 400 - {'error': {'message': 'Failed to initialize samplers: failed to parse grammar', ...}}
```

Every layout (`SURYA_GUIDED_LAYOUT`) and table-rec (`SURYA_GUIDED_TABLE_REC`)
request through the `llamacpp` backend fails at slot launch. See also
ggml-org/llama.cpp#16714.

## Fix

Use the explicit character class `[0-9]` in both patterns. It is an ordinary
character class that GBNF, vLLM's guided decoding, and Python's `re` all
accept, so the llama.cpp path stops erroring while the vLLM path is unaffected.

## Behaviour check

`[0-9]` is `\d` minus the non-ASCII digit codepoints. Since the parser turns
these fields into pixel coordinates, that narrowing is the intended set:

| input | `\d` | `[0-9]` |
|---|---|---|
| `0 0 1000 1000` | ✅ | ✅ |
| `12 3 456 7890` | ✅ | ✅ |
| `12345 0 0 0` (>4 digits) | ❌ | ❌ |
| `0 0 1000` (3 fields) | ❌ | ❌ |
| `a b c d` | ❌ | ❌ |
| `١٢ ٣ ٤ ٥` (Arabic-Indic) | ✅ | ❌ |
| `１２ 3 4 5` (fullwidth) | ✅ | ❌ |

Only the last two rows change, and neither is a shape the model emits or the
downstream bbox parser expects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
