### PR TITLE
fix(inference): stop waiting on a spawned server that already exited

### DIFF
--- a/surya/inference/backends/spawn.py
+++ b/surya/inference/backends/spawn.py
@@ -56,12 +56,26 @@ def probe_health(base_url: str, timeout: float = 1.0) -> bool:
 
 
 def wait_for_health(
-    base_url: str, total_timeout: float = 300.0, interval: float = 1.0
+    base_url: str,
+    total_timeout: float = 300.0,
+    interval: float = 1.0,
+    is_alive: Optional[Callable[[], Optional[bool]]] = None,
 ) -> bool:
+    """Polls `/health` until the server answers, the server dies, or we time out.
+
+    `is_alive`, when given, reports whether the spawned server is still running
+    (`None` when that cannot be determined). A server that has already exited is
+    never going to answer, so we stop waiting instead of burning the whole
+    timeout on a process that is gone.
+    """
     deadline = time.time() + total_timeout
     while time.time() < deadline:
         if probe_health(base_url):
             return True
+        if is_alive is not None and is_alive() is False:
+            # Re-probe once: the server may have come up and exited between the
+            # health probe above and this check.
+            return probe_health(base_url)
         time.sleep(interval)
     return False
 
@@ -136,6 +150,30 @@ def _stop_process(pid: int, name: str) -> None:
         pass
     except Exception as e:
         logger.warning(f"Failed to stop {name} (pid {pid}): {e}")
+
+
+def _server_is_alive(handle: "SpawnHandle") -> Optional[bool]:
+    """Whether the spawned server is still running; None when undeterminable."""
+    try:
+        if handle.cleanup_kind == "docker":
+            r = subprocess.run(
+                ["docker", "inspect", "-f", "{{.State.Running}}", handle.cleanup_id],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if r.returncode != 0:
+                # No such container: it exited and `--rm` already reaped it.
+                return False
+            return r.stdout.strip() == "true"
+        if handle.cleanup_kind == "process" and handle.pid:
+            os.kill(handle.pid, 0)
+            return True
+    except ProcessLookupError:
+        return False
+    except Exception:
+        return None
+    return None
 
 
 def _capture_server_logs(handle: "SpawnHandle", backend: str, tail: int = 100) -> str:
@@ -338,17 +376,27 @@ def attach_or_spawn(
 
         # 6. Wait for health
         health_url = health_url_for(port)
-        if not wait_for_health(health_url, total_timeout=startup_timeout):
+        if not wait_for_health(
+            health_url,
+            total_timeout=startup_timeout,
+            is_alive=lambda: _server_is_alive(spawn_handle),
+        ):
             # Grab the server's own logs *before* cleanup tears the (--rm)
             # container down, otherwise the actual failure reason is lost and
             # all the caller sees is this timeout.
+            died = _server_is_alive(spawn_handle) is False
             logs = _capture_server_logs(spawn_handle, backend)
             _cleanup()
-            raise SpawnError(
-                f"{backend} server failed to become healthy at {health_url} "
-                f"within {startup_timeout}s.\n"
-                f"--- last {backend} server logs ---\n{logs}"
-            )
+            if died:
+                reason = (
+                    f"{backend} server exited before becoming healthy at {health_url}."
+                )
+            else:
+                reason = (
+                    f"{backend} server failed to become healthy at {health_url} "
+                    f"within {startup_timeout}s."
+                )
+            raise SpawnError(f"{reason}\n--- last {backend} server logs ---\n{logs}")
 
         # 7. Verify model name
         running_model = probe_model_id(openai_url_for(port))


### PR DESCRIPTION
Reported in datalab-to/marker#1070.

## The problem

`attach_or_spawn` spawns the vllm container, then calls `wait_for_health(health_url, total_timeout=startup_timeout)`. That loop only ever asks the port — never the thing it just started. When the container exits during startup (bad GPU flags, OOM, image mismatch), `docker run --rm` reaps it and the port stays dead, so the loop keeps polling for the full `startup_timeout` — 600s by default. Then `_capture_server_logs` shells out to `docker logs` on a container that no longer exists, and its stderr is printed under the "server logs" heading:

```
surya.inference.backends.spawn.SpawnError: vllm server failed to become healthy at http://127.0.0.1:49125 within 600.0s.
--- last vllm server logs ---
Error response from daemon: No such container: surya-vllm-49125
```

Ten minutes of waiting, and the message says "timed out" when the server was already gone — the docker error is the only hint, and it reads like a log line rather than a diagnosis.

## The change

* `wait_for_health` takes an optional `is_alive` probe. When it reports `False`, the wait stops instead of running out the clock. It re-probes `/health` once first, so a server that came up and exited between the two checks is still reported correctly.
* New `_server_is_alive(handle)`: `docker inspect -f {{.State.Running}}` for the docker backend, `os.kill(pid, 0)` for the process backend. It returns `None` (not `False`) whenever the answer can't be determined, and `wait_for_health` only bails on an explicit `False` — an unknown state keeps the old waiting behaviour.
* The `SpawnError` distinguishes the two cases: *exited before becoming healthy* vs. *failed to become healthy within Ns*.

A running server is untouched: the alive probe never returns `False`, so both the eventually-healthy and never-healthy paths behave exactly as before.

## Verification

Stubbing `subprocess.run` (docker inspect/logs on a reaped container) and `probe_health` (never healthy), against `startup_timeout=6s`:

| | wait | message |
|---|---|---|
| before | 6.0s (full timeout) | `vllm server failed to become healthy at ... within 6.0s.` |
| after | 0.0s | `vllm server exited before becoming healthy at ...` |

Both still print the captured docker output under the logs heading, so nothing is lost.

Regression check with the container reported as running (`{{.State.Running}}` → `true`), `startup_timeout=5s`:

| scenario | before | after |
|---|---|---|
| healthy at 2s | 2.0s, attaches | 2.0s, attaches |
| never healthy | 5.0s, timeout error | 5.0s, same timeout error |

`ruff check` and `ruff format --diff` clean at the pinned v0.9.10 with the repo's `pyproject.toml`.

## Note

I did not touch `_capture_server_logs`. Surfacing docker's "No such container" under a "server logs" heading is still a little misleading, but with the fast-fail message above it now, the reason is no longer ambiguous — and a narrower change is easier to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
