### PR TITLE
fix(inference): bind the auto-spawned vLLM container to SURYA_INFERENCE_HOST (#547)

### DIFF
--- a/surya/inference/backends/vllm.py
+++ b/surya/inference/backends/vllm.py
@@ -157,7 +157,7 @@ class VllmBackend(Backend):
                 "-v",
                 f"{hf_cache}:/root/.cache/huggingface",
                 "-p",
-                f"{port}:8000",
+                f"{settings.SURYA_INFERENCE_HOST}:{port}:8000",
                 "--ipc=host",
                 settings.VLLM_DOCKER_IMAGE,
                 "--model",


### PR DESCRIPTION
## What

The auto-spawned vLLM container is published with `-p {port}:8000` — no host address — so Docker binds it to **all** host interfaces (`0.0.0.0` and `[::]`). Since `SURYA_INFERENCE_AUTOSTART` defaults to `True`, an ordinary local OCR call opens an unauthenticated GPU inference endpoint to the LAN (and to a tailnet/VPN, if present).

`settings.SURYA_INFERENCE_HOST` already defaults to `127.0.0.1`, and both `_health_url()` and `_openai_url()` dial through it — so a reader of the settings would reasonably conclude the server is loopback-scoped. It isn't: the publish binding ignores the setting.

## Fix

Honor the existing host setting in the publish mapping:

```python
"-p",
f"{settings.SURYA_INFERENCE_HOST}:{port}:8000",
```

- Default (`127.0.0.1`) now binds loopback-only, matching the dial address the health check already uses.
- Anyone who deliberately sets `SURYA_INFERENCE_HOST=0.0.0.0` keeps the current all-interfaces behaviour.

One line, no new settings, no behaviour change for explicit `0.0.0.0` operators.

Fixes #547.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
