### PR TITLE
Update VLLM_DOCKER_IMAGE to use docker.io prefix

### DIFF
--- a/surya/settings.py
+++ b/surya/settings.py
@@ -93,7 +93,7 @@ class Settings(BaseSettings):
     BBOX_SCALE: int = 1000
 
     # vllm
-    VLLM_DOCKER_IMAGE: str = "vllm/vllm-openai:v0.20.1"
+    VLLM_DOCKER_IMAGE: str = "docker.io/vllm/vllm-openai:v0.20.1"
     VLLM_API_KEY: str = "EMPTY"
     VLLM_GPUS: str = "0"
     VLLM_GPU_TYPE: str = "4090"


### PR DESCRIPTION
For now podman , and kubernetes and maybe other force to create the docker.io prefix for image because it can't imagine where the container image is hosted and for security reason

https://github.com/kubernetes-sigs/kind/issues/2186 https://github.com/podman-container-tools/podman/issues/11530

this modification help podman and other work bether

exemple of what its does

https://github.com/remnawave/backend/issues/138