### PR TITLE
fix(batch_service): stop doubling the /v1 prefix on the infer route

### DIFF
--- a/surya/common/batch_service/client.py
+++ b/surya/common/batch_service/client.py
@@ -24,6 +24,12 @@ from surya.logging import get_logger
 logger = get_logger()
 
 
+def _server_root(base_url: str) -> str:
+    """Strip the OpenAI-style "/v1" suffix, leaving the server root."""
+    root = base_url.rstrip("/")
+    return root[: -len("/v1")] if root.endswith("/v1") else root
+
+
 class BatchServiceClient:
     def __init__(
         self,
@@ -96,7 +102,14 @@ class BatchServiceClient:
             )
             self._base_url = spawned.base_url
             self._http = httpx.Client(
-                base_url=self._base_url,
+                # `base_url` is the OpenAI-style endpoint, so it normally ends in
+                # "/v1" (see `_openai_url`, and the documented form of the pinned
+                # `<PREFIX>_SERVER_URL`). httpx *appends* a request path to the
+                # base path instead of replacing it, so posting "/v1/infer"
+                # against ".../v1" would go out as "/v1/v1/infer". Anchor the
+                # client at the server root so the documented "/v1/infer" route
+                # is what actually reaches the server.
+                base_url=_server_root(self._base_url),
                 # connect fails fast if the server is gone; reads can be long
                 # (large batches). No keep-alive: avoids reusing a stale socket to
                 # a server that has since died, which would hang instead of erroring.

--- a/tests/test_batch_service_client.py
+++ b/tests/test_batch_service_client.py
@@ -1,0 +1,97 @@
+"""Batch-service client: the request path put on the wire.
+
+Torch-free and model-free - a stub HTTP server stands in for the real service,
+so these run anywhere.
+"""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from surya.common.batch_service.client import BatchServiceClient
+from surya.common.batch_service.config import ServiceConfig
+from surya.inference.backends import spawn as spawn_mod
+
+
+@pytest.fixture
+def recording_server():
+    """A stub batch server that records the path of every POST it receives.
+
+    It answers any path so a wrong route shows up as a recorded value rather
+    than as a 404 the client would surface as some other failure.
+    """
+    paths = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            paths.append(self.path)
+            length = int(self.headers.get("Content-Length", 0))
+            req = json.loads(self.rfile.read(length))
+            body = json.dumps({"results": list(req.get("items", []))}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            pass
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    yield httpd.server_address[1], paths
+    httpd.shutdown()
+    httpd.server_close()
+
+
+def _client(monkeypatch, port, base_suffix):
+    """A client pinned to the stub server, with `attach_or_spawn` stubbed out."""
+    base = f"http://127.0.0.1:{port}{base_suffix}"
+
+    def fake_attach_or_spawn(**kwargs):
+        return spawn_mod.SpawnedServer(
+            base_url=base,
+            health_url=f"http://127.0.0.1:{port}",
+            model_name="stub",
+            pid=None,
+            backend="stub",
+            spawned_by_us=False,
+        )
+
+    monkeypatch.setattr(
+        "surya.common.batch_service.client.attach_or_spawn", fake_attach_or_spawn
+    )
+    config = ServiceConfig(
+        backend="stub",
+        model_name="stub",
+        server_module="stub",
+        host="127.0.0.1",
+        external_url=base,
+        port=port,
+        autostart=False,
+        startup_timeout=5.0,
+        request_timeout=10.0,
+        batch_wait_ms=0,
+        max_batch=8,
+    )
+    return BatchServiceClient(
+        config, encode_item=lambda i: i, decode_result=lambda r: r
+    )
+
+
+@pytest.mark.parametrize("base_suffix", ["/v1", "", "/v1/"])
+def test_infer_posts_documented_route(monkeypatch, recording_server, base_suffix):
+    """`infer` hits `/v1/infer` regardless of whether the resolved base URL
+    already carries the OpenAI-style `/v1` prefix.
+
+    The spawned base URL ends in `/v1` (see `BatchServiceClient._openai_url`),
+    and httpx joins a leading-slash path onto the base path rather than
+    replacing it, so a naive `post("/v1/infer")` goes out as `/v1/v1/infer`.
+    """
+    port, paths = recording_server
+    client = _client(monkeypatch, port, base_suffix)
+
+    assert client.infer([1, 2, 3]) == [1, 2, 3]
+    assert paths == ["/v1/infer"]


### PR DESCRIPTION
## What

`BatchServiceClient.infer()` puts `/v1/v1/infer` on the wire instead of the documented `/v1/infer`.

The client resolves an OpenAI-style base URL that ends in `/v1` — `_openai_url()` builds it that way for a spawned server, and the documented form of a pinned `<PREFIX>_SERVER_URL` carries it too (`surya/settings.py`: *"e.g. `http://127.0.0.1:8920/v1`"*) — and then posts to the **absolute** path `/v1/infer`. httpx *appends* a request path to the base URL's path rather than replacing it:

```python
>>> httpx.Client(base_url="http://127.0.0.1:8765/v1").build_request("POST", "/v1/infer").url
URL('http://127.0.0.1:8765/v1/v1/infer')
```

This is normally invisible, because the bundled server routes on a suffix match:

```python
# surya/common/batch_service/server.py
def do_POST(self):
    if not self.path.rstrip("/").endswith("/infer"):
        return self._send_json(404, {"error": "not found"})
```

so surya's own server happily accepts the doubled path. It surfaces against anything that routes on the documented path exactly — a reverse proxy, an API gateway, or a sidecar in front of a pinned `<PREFIX>_SERVER_URL`.

## Fix

Anchor the httpx client at the server root, so the `/v1/infer` written at the call site is what actually goes out. `self._base_url` itself is unchanged (it stays the OpenAI-style URL); only the base handed to httpx is rooted.

Deliberately *not* changing the call site to a relative `"infer"`: that would resolve to `/infer` when the base URL carries no `/v1`, silently moving that deployment's route instead of leaving it alone.

## Test

`tests/test_batch_service_client.py` is torch- and model-free — a stub HTTP server records the path of each POST — so it runs anywhere. It is parametrized over the three base-URL shapes that reach the client:

| base URL | before | after |
|---|---|---|
| `http://…:PORT/v1` (spawned, and the documented pinned form) | `/v1/v1/infer` ❌ | `/v1/infer` ✅ |
| `http://…:PORT/v1/` (trailing slash) | `/v1/v1/infer` ❌ | `/v1/infer` ✅ |
| `http://…:PORT` (pinned without `/v1`) | `/v1/infer` ✅ | `/v1/infer` ✅ |

The third row already passed before this change and is included to pin down that it does not regress.

```
$ python -m pytest tests/test_batch_service_client.py -q
# on master: 2 failed, 1 passed  -> AssertionError: assert ['/v1/v1/infer'] == ['/v1/infer']
# with fix:  3 passed
```

`ruff check` / `ruff format --check` clean at the pinned `v0.9.10` from `.pre-commit-config.yaml`.

## Note on #1086

This is the `/v1/v1` doubling that [datalab-to/marker#1086](https://github.com/datalab-to/marker/issues/1086) reports, but I do not think it is the cause of the `500` in that traceback. Because the server suffix-matches `/infer`, the doubled path still reaches the handler, and the `500` there comes from the `job.error is not None` branch — a real inference failure — rather than from routing. Fixing the path is worth doing on its own; that report likely needs a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
