### PR TITLE
fix(rfdetr): resolve s3:// fast-model checkpoints instead of crashing

### DIFF
--- a/surya/common/rfdetr_torch.py
+++ b/surya/common/rfdetr_torch.py
@@ -195,9 +195,15 @@ def resolve_model_dir(checkpoint: str) -> str:
     if checkpoint and os.path.isdir(checkpoint):
         return checkpoint
     if checkpoint and checkpoint.startswith("s3://"):
-        from surya.common.s3 import download_directory  # type: ignore
+        from surya.common.s3 import (  # type: ignore
+            S3DownloaderMixin,
+            download_directory,
+        )
 
-        return download_directory(checkpoint)
+        local_path = S3DownloaderMixin.get_local_path(checkpoint)
+        remote = checkpoint.replace(S3DownloaderMixin.s3_prefix, "")
+        download_directory(remote, local_path)
+        return local_path
     raise FileNotFoundError(
         f"fast-model checkpoint not found as a local dir: {checkpoint!r}"
     )


### PR DESCRIPTION
## Problem

`resolve_model_dir` (`surya/common/rfdetr_torch.py`) claims to support `s3://` fast-model checkpoints, but that branch cannot run:

```python
if checkpoint and checkpoint.startswith("s3://"):
    from surya.common.s3 import download_directory  # type: ignore

    return download_directory(checkpoint)
```

`download_directory` is `def download_directory(remote_path: str, local_dir: str)`, so the call raises

```
TypeError: download_directory() missing 1 required positional argument: 'local_dir'
```

before anything is fetched. Two further defects sit behind the arity one:

* the raw checkpoint is passed as `remote_path` with the `s3://` prefix still attached — every other caller strips it first, so the S3 URL would be built with a doubled scheme;
* `download_directory` returns `None`, so `return download_directory(...)` would return `None` out of a `-> str` function even once it accepted the arguments.

Reachable from both call sites of `resolve_model_dir`: `surya/fast_layout/server.py:29` and `surya/common/order/predictor.py:114`.

## Sibling baseline

`surya/ocr_error/loader.py::_resolve_checkpoint` is the same routine, written correctly — it is what this patch mirrors:

```python
local_path = S3DownloaderMixin.get_local_path(checkpoint)
remote = checkpoint.replace(S3DownloaderMixin.s3_prefix, "")
download_directory(remote, local_path)
...
return local_path
```

`S3DownloaderMixin.from_pretrained` (`s3.py:166`) does the same split of destination vs. remote.

## Fix

```diff
     if checkpoint and checkpoint.startswith("s3://"):
-        from surya.common.s3 import download_directory  # type: ignore
+        from surya.common.s3 import (  # type: ignore
+            S3DownloaderMixin,
+            download_directory,
+        )
 
-        return download_directory(checkpoint)
+        local_path = S3DownloaderMixin.get_local_path(checkpoint)
+        remote = checkpoint.replace(S3DownloaderMixin.s3_prefix, "")
+        download_directory(remote, local_path)
+        return local_path
```

## Verification

I do not have S3 credentials, so I executed the real `resolve_model_dir` source sliced out of `rfdetr_torch.py` with `surya.common.s3` swapped for a recorder whose `download_directory` signature is rebuilt from the real `s3.py` AST (never hand-typed), and `get_local_path` reproducing the real one:

```
real download_directory signature (from s3.py AST): ['remote_path', 'local_dir']

--- unpatched (current master) ---
  TypeError: download_directory() missing 1 required positional argument: 'local_dir'
  download_directory called with: []

--- patched ---
  returned: '<MODEL_CACHE_DIR>/surya/fast_layout/2026_01_01'
  download_directory called with: [('surya/fast_layout/2026_01_01',
                                    '<MODEL_CACHE_DIR>/surya/fast_layout/2026_01_01')]
```

Note the recorded `remote_path` no longer carries the `s3://` prefix.

The other two branches are untouched and re-checked against the patched function:

```
  local dir  -> 'D:/.../scan0828d'   (returned unchanged)
  bad path   -> FileNotFoundError: fast-model checkpoint not found as a local dir: '/definitely/not/a/dir'
```

`ruff format --check` and `ruff check` are clean on the changed file.

## Deliberately not changed

`_resolve_checkpoint` and `from_pretrained` both wrap `download_directory` in a 3-attempt retry loop. I left that out to keep this to the crash fix; happy to add it if you would rather the three s3 paths stay identical.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
