### PR TITLE
add `SURYA_INFERENCE_API_KEY` for llamacpp + vllm

### DIFF
--- a/surya/inference/backends/llamacpp.py
+++ b/surya/inference/backends/llamacpp.py
@@ -97,7 +97,10 @@ class LlamaCppBackend(Backend):
                 model_name=spawned.model_name,
                 spawned_by_us=spawned.spawned_by_us,
             )
-            self._client = OpenAI(api_key="EMPTY", base_url=self.handle.base_url)
+            self._client = OpenAI(
+                api_key=settings.SURYA_INFERENCE_API_KEY,
+                base_url=self.handle.base_url,
+            )
             return self.handle
 
         binary = _resolve_llama_server_binary()
@@ -187,7 +190,7 @@ class LlamaCppBackend(Backend):
             spawned_by_us=spawned.spawned_by_us,
         )
         self._client = OpenAI(
-            api_key="EMPTY",
+            api_key=settings.SURYA_INFERENCE_API_KEY,
             base_url=self.handle.base_url,
         )
         return self.handle

--- a/surya/inference/backends/vllm.py
+++ b/surya/inference/backends/vllm.py
@@ -132,7 +132,7 @@ class VllmBackend(Backend):
                 spawned_by_us=spawned.spawned_by_us,
             )
             self._client = OpenAI(
-                api_key=settings.VLLM_API_KEY, base_url=self.handle.base_url
+                api_key=settings.SURYA_INFERENCE_API_KEY, base_url=self.handle.base_url
             )
             return self.handle
 
@@ -211,7 +211,7 @@ class VllmBackend(Backend):
             spawned_by_us=spawned.spawned_by_us,
         )
         self._client = OpenAI(
-            api_key=settings.VLLM_API_KEY,
+            api_key=settings.SURYA_INFERENCE_API_KEY,
             base_url=self.handle.base_url,
         )
         return self.handle

--- a/surya/settings.py
+++ b/surya/settings.py
@@ -3,7 +3,7 @@ from typing import Callable, Dict, Optional
 
 import torch
 from dotenv import find_dotenv
-from pydantic import computed_field
+from pydantic import computed_field, model_validator
 from pydantic_settings import BaseSettings
 from pathlib import Path
 from platformdirs import user_cache_dir
@@ -48,6 +48,7 @@ class Settings(BaseSettings):
     # Backend selection
     SURYA_INFERENCE_BACKEND: Optional[str] = None  # "vllm" | "llamacpp" | None (auto)
     SURYA_INFERENCE_URL: Optional[str] = None  # external server, skip spawn
+    SURYA_INFERENCE_API_KEY: Optional[str] = None
     SURYA_INFERENCE_AUTOSTART: bool = True
     # Leave an auto-spawned server running after the process exits so later
     # commands attach to it instead of re-spawning (avoids repeated startup /
@@ -94,7 +95,7 @@ class Settings(BaseSettings):
 
     # vllm
     VLLM_DOCKER_IMAGE: str = "vllm/vllm-openai:v0.20.1"
-    VLLM_API_KEY: str = "EMPTY"
+    VLLM_API_KEY: Optional[str] = None  # legacy alias for SURYA_INFERENCE_API_KEY
     VLLM_GPUS: str = "0"
     VLLM_GPU_TYPE: str = "4090"
     # bfloat16 needs an Ampere+ GPU (compute capability >= 8.0). On older cards
@@ -200,6 +201,13 @@ class Settings(BaseSettings):
     RECOGNITION_FONT_DL_BASE: str = (
         "https://github.com/satbyy/go-noto-universal/releases/download/v7.0"
     )
+
+    @model_validator(mode="after")
+    def _resolve_api_key(self):
+        # API key precedence: 1. SURYA_INFERENCE_API_KEY, 2. VLLM_API_KEY, 3. "EMPTY"
+        if not self.SURYA_INFERENCE_API_KEY:
+            self.SURYA_INFERENCE_API_KEY = self.VLLM_API_KEY or "EMPTY"
+        return self
 
     @computed_field
     def MODEL_DTYPE(self) -> torch.dtype:


### PR DESCRIPTION
Currently, a llama.cpp backend cannot be used with an API key. For vLLM, it is possible to use `VLLM_API_KEY`.

This PR introduces the new configuration variable `SURYA_INFERENCE_API_KEY` as a common variable for the API key, used for both the llama.cpp and vLLM backends.

If `SURYA_INFERENCE_API_KEY` is not set, `VLLM_API_KEY` is used as a fallback.